### PR TITLE
Remove default actix-web features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 exclude = [".travis.yml", ".gitignore"]
 
 [dependencies]
-actix-web = "0.7"
+actix-web = { version = "0.7", default_features = false }
 bytes = "0.4"
 base64 = "0.9"
 


### PR DESCRIPTION
By default actix-web pulls in cookie which pulls in Ring which makes it unbuildable for non x86 or ARM architectures. 

Since this package doesn't seem to have any need of any features beyond the Actix middleware interface I figured I could toss this upstream. 

I'd still like to test it with code using the various default features to see if I'm accidentally breaking anything. 