### PR TITLE
Tighten HttpAuthentication::with_fn bound from FnMut to Fn.

### DIFF
--- a/examples/middleware-closure.rs
+++ b/examples/middleware-closure.rs
@@ -1,0 +1,18 @@
+use actix_web::{middleware, web, App, HttpServer};
+
+use futures::future;
+
+use actix_web_httpauth::middleware::HttpAuthentication;
+
+fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        let auth = HttpAuthentication::basic(|req, _credentials| future::ok(req));
+        App::new()
+            .wrap(middleware::Logger::default())
+            .wrap(auth)
+            .service(web::resource("/").to(|| "Test\r\n"))
+    })
+    .bind("127.0.0.1:8080")?
+    .workers(1)
+    .run()
+}

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -34,7 +34,7 @@ where
 impl<T, F, O> HttpAuthentication<T, F>
 where
     T: AuthExtractor,
-    F: FnMut(ServiceRequest, T) -> O,
+    F: Fn(ServiceRequest, T) -> O,
     O: IntoFuture<Item = ServiceRequest, Error = Error>,
 {
     /// Construct `HttpAuthentication` middleware
@@ -50,7 +50,7 @@ where
 
 impl<F, O> HttpAuthentication<basic::BasicAuth, F>
 where
-    F: FnMut(ServiceRequest, basic::BasicAuth) -> O,
+    F: Fn(ServiceRequest, basic::BasicAuth) -> O,
     O: IntoFuture<Item = ServiceRequest, Error = Error>,
 {
     /// Construct `HttpAuthentication` middleware for the HTTP "Basic"
@@ -86,7 +86,7 @@ where
 
 impl<F, O> HttpAuthentication<bearer::BearerAuth, F>
 where
-    F: FnMut(ServiceRequest, bearer::BearerAuth) -> O,
+    F: Fn(ServiceRequest, bearer::BearerAuth) -> O,
     O: IntoFuture<Item = ServiceRequest, Error = Error>,
 {
     /// Construct `HttpAuthentication` middleware for the HTTP "Bearer"


### PR DESCRIPTION
Three constructor functions for `HttpAuthentication` only requires `F: FnMut`. However, the constructed instances are only usable when `F: Fn`. This is unfortunate for closures, since the passed closure will be inferred to be only `FnMut` when it only captures immutably.

```rust
use actix_web::{middleware, web, App, HttpServer};

use futures::future;

use actix_web_httpauth::middleware::HttpAuthentication;

fn main() -> std::io::Result<()> {
    HttpServer::new(|| {
        let auth = HttpAuthentication::basic(|req, _credentials| future::ok(req));
        App::new()
            .wrap(middleware::Logger::default())
            .wrap(auth) // Compile fails here
            .service(web::resource("/").to(|| "Test\r\n"))
    })
    .bind("127.0.0.1:8080")?
    .workers(1)
    .run()
}
```

Technically it's a breaking change, but as it's actually unusable without `F: Fn`, I'd think it's considered a bugfix. If this is unsuitable, I'll prepare another PR that introduces `HttpAuthentication::with_fn2` etc.