### PR TITLE
Let the validation function decide whether to continue / abort request

### DIFF
--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -6,7 +6,7 @@ use actix_web_httpauth::middleware::HttpAuthentication;
 
 async fn validator(
     req: ServiceRequest,
-    _credentials: BasicAuth,
+    _credentials: Option<BasicAuth>,
 ) -> Result<ServiceRequest, Error> {
     Ok(req)
 }

--- a/src/headers/authorization/scheme/basic.rs
+++ b/src/headers/authorization/scheme/basic.rs
@@ -80,7 +80,10 @@ impl Scheme for Basic {
                 }
             })?;
 
-        Ok(Basic { user_id, password })
+        Ok(Basic {
+            user_id,
+            password,
+        })
     }
 }
 

--- a/src/headers/authorization/scheme/basic.rs
+++ b/src/headers/authorization/scheme/basic.rs
@@ -5,7 +5,6 @@ use std::str;
 use actix_web::http::header::{
     HeaderValue, IntoHeaderValue, InvalidHeaderValue,
 };
-use base64;
 use bytes::{BufMut, BytesMut};
 
 use crate::headers::authorization::errors::ParseError;
@@ -81,10 +80,7 @@ impl Scheme for Basic {
                 }
             })?;
 
-        Ok(Basic {
-            user_id,
-            password,
-        })
+        Ok(Basic { user_id, password })
     }
 }
 


### PR DESCRIPTION
... processing based on the request, and the presence or absence of credentials.

This is a breaking change compared to the current implementation
The validation function is now defined as `Fn(ServiceRequest, Option<T>) -> O` instead of `Fn(ServiceRequest, T) -> O`.
This allows to cater for cases where e.g. some routes don't require authentication, or some other application-specific authorization logic.

Another approach could be to add a middleware setting to decide whether to abort the request if there is no credentials present in the request.